### PR TITLE
Lamby Commit, and some tests.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,7 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# test lamby projects
+
+.lamby/*

--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,6 @@ venv.bak/
 
 # vscode
 .vscode/*
+
+# sandbox for manual testing
+sandbox/*

--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,6 @@ venv.bak/
 # test lamby projects
 
 .lamby/*
+
+# vscode
+.vscode/*

--- a/file1.onnx
+++ b/file1.onnx
@@ -1,1 +1,0 @@
-Hello  Hi

--- a/file1.onnx
+++ b/file1.onnx
@@ -1,0 +1,1 @@
+Hello  Hi

--- a/lamby/lamby.py
+++ b/lamby/lamby.py
@@ -60,7 +60,7 @@ def commit(files, message):
             click.echo(file + ' is not a file')
             continue
 
-        if os.path.splitext(file)[1] != 'onnx':
+        if file.split('.')[-1] != 'onnx':
             click.echo(file + ' is not an onnx file')
             continue
 

--- a/lamby/lamby.py
+++ b/lamby/lamby.py
@@ -14,7 +14,7 @@ def cli():
 
 @cli.command()
 def init():
-    lamby_dir = os.getcwd() + '/.lamby'
+    lamby_dir = './.lamby'
     if os.path.isdir(lamby_dir):
         click.echo('Lamby project already initialized in ' + os.getcwd())
         return
@@ -35,7 +35,7 @@ def init():
 
 @cli.command()
 def uninit():
-    lamby_dir = os.getcwd() + '/.lamby'
+    lamby_dir = './.lamby'
     if not os.path.isdir(lamby_dir):
         click.echo('Lamby project has not been initialized in ' + os.getcwd())
         return
@@ -48,7 +48,7 @@ def uninit():
 @click.argument('files', nargs=-1)
 @click.option('-m', '--message')
 def commit(files, message):
-    lamby_dir = os.getcwd() + '/.lamby'
+    lamby_dir = './.lamby'
     if not os.path.isdir(lamby_dir):
         click.echo('Lamby project has not been initialized in ' + os.getcwd())
         return
@@ -101,27 +101,27 @@ def commit(files, message):
 
 
 def deserialize_log():
-    if not os.path.isfile(os.getcwd() + '/.lamby/log'):
+    if not os.path.isfile('./.lamby/log'):
         return {}
-    with open(os.getcwd() + '/.lamby/log') as log_file:
+    with open('./.lamby/log') as log_file:
         return json.load(log_file)
 
 
 def deserialize_config():
-    if not os.path.isfile(os.getcwd() + '/.lamby/config'):
+    if not os.path.isfile('./.lamby/config'):
         return {}
-    with open(os.getcwd() + '/.lamby/config') as config_file:
+    with open('./.lamby/config') as config_file:
         return json.load(config_file)
 
 
 def serialize_log(data):
-    with open(os.getcwd() + '/.lamby/log', 'w+') as log_file:
+    with open('./.lamby/log', 'w+') as log_file:
         log_file.write(json.dumps(data))
         log_file.close()
 
 
 def serialize_config(data):
-    with open(os.getcwd() + '/.lamby/config', 'w+') as config_file:
+    with open('./.lamby/config', 'w+') as config_file:
         config_file.write(json.dumps(data))
         config_file.close()
 

--- a/lamby/lamby.py
+++ b/lamby/lamby.py
@@ -4,6 +4,7 @@ import shutil
 import json
 import time
 import hashlib
+import gzip
 
 
 @click.group()
@@ -71,8 +72,16 @@ def commit(files, message):
 
         str_to_hash = str_to_hash.encode("utf-8")
 
-        commit_record["hash"] = hashlib.sha256(str_to_hash).hexdigest()
+        hash_gen = hashlib.sha256(str_to_hash).hexdigest()
+
+        commit_record["hash"] = hash_gen
         log[file].append(commit_record)
+
+        with open(file, 'rb') as commit_file:
+            with gzip.open('./.lamby/' + hash_gen, 'wb') as zipped_commit:
+                zipped_commit.writelines(commit_file)
+                zipped_commit.close()
+                commit_file.close()
 
     serialize_log(log)
 

--- a/lamby/lamby.py
+++ b/lamby/lamby.py
@@ -55,7 +55,7 @@ def commit(files, message):
         click.echo('Lamby project has not been initialized in ' + os.getcwd())
         sys.exit(1)
 
-    if len(files) == 0:
+    if files is None or len(files) == 0:
         files = search_file_type('.', 'onnx')
 
     log = deserialize_log()

--- a/lamby/lamby.py
+++ b/lamby/lamby.py
@@ -2,6 +2,8 @@ import click
 import os
 import shutil
 import json
+import time
+import hashlib
 
 
 @click.group()
@@ -48,11 +50,65 @@ def commit(files, message):
     if not os.path.isdir(lamby_dir):
         click.echo('Lamby project has not been initialized in ' + os.getcwd())
         return
-    click.echo('Commiting following files:')
+
+    log = deserialize_log()
+
     for file in files:
-        click.echo('\t' + file)
-    if message is not None:
-        click.echo('Commit Message: ' + message)
+        if file not in log:
+            log[file] = []
+
+        commit_record = {}
+        commit_record["timestamp"] = int(time.time())
+        commit_record["message"] = message
+
+        str_to_hash = os.path.basename(file)
+        str_to_hash += str(commit_record["timestamp"])
+        str_to_hash += commit_record["message"]
+        str_to_hash += file_sha256(file)
+
+        if len(log[file]) > 0:
+            str_to_hash += log[file][-1]["hash"]
+
+        str_to_hash = str_to_hash.encode("utf-8")
+
+        commit_record["hash"] = hashlib.sha256(str_to_hash).hexdigest()
+        log[file].append(commit_record)
+
+    serialize_log(log)
+
+
+def deserialize_log():
+    if not os.path.isfile(os.getcwd() + '/.lamby/log'):
+        return {}
+    with open(os.getcwd() + '/.lamby/log') as log_file:
+        return json.load(log_file)
+
+
+def deserialize_config():
+    if not os.path.isfile(os.getcwd() + '/.lamby/config'):
+        return {}
+    with open(os.getcwd() + '/.lamby/config') as config_file:
+        return json.load(config_file)
+
+
+def serialize_log(data):
+    with open(os.getcwd() + '/.lamby/log', 'w+') as log_file:
+        log_file.write(json.dumps(data))
+        log_file.close()
+
+
+def serialize_config(data):
+    with open(os.getcwd() + '/.lamby/config', 'w+') as config_file:
+        config_file.write(json.dumps(data))
+        config_file.close()
+
+
+def file_sha256(fname):
+    hash_sha256 = hashlib.sha256()
+    with open(fname, "rb") as f:
+        for chunk in iter(lambda: f.read(4096), b""):
+            hash_sha256.update(chunk)
+    return hash_sha256.hexdigest()
 
 
 if __name__ == '__main__':

--- a/lamby/lamby.py
+++ b/lamby/lamby.py
@@ -56,6 +56,14 @@ def commit(files, message):
     log = deserialize_log()
 
     for file in files:
+        if not os.path.isfile(file):
+            click.echo(file + ' is not a file')
+            continue
+
+        if os.path.splitext(file)[1] != 'onnx':
+            click.echo(file + ' is not an onnx file')
+            continue
+
         if file not in log:
             log[file] = []
 

--- a/lamby/lamby.py
+++ b/lamby/lamby.py
@@ -6,6 +6,7 @@ import time
 import hashlib
 import gzip
 import glob
+import sys
 
 
 @click.group()
@@ -18,7 +19,7 @@ def init():
     lamby_dir = './.lamby'
     if os.path.isdir(lamby_dir):
         click.echo('Lamby project already initialized in ' + os.getcwd())
-        return
+        sys.exit(1)
 
     os.mkdir(lamby_dir)
     os.mkdir(lamby_dir + '/commit_objects')
@@ -39,7 +40,7 @@ def uninit():
     lamby_dir = './.lamby'
     if not os.path.isdir(lamby_dir):
         click.echo('Lamby project has not been initialized in ' + os.getcwd())
-        return
+        sys.exit(1)
     click.echo('Removing Lamby project in ' + os.getcwd())
 
     shutil.rmtree(lamby_dir)
@@ -52,7 +53,7 @@ def commit(files, message):
     lamby_dir = './.lamby'
     if not os.path.isdir(lamby_dir):
         click.echo('Lamby project has not been initialized in ' + os.getcwd())
-        return
+        sys.exit(1)
 
     if len(files) == 0:
         files = search_file_type('.', 'onnx')

--- a/lamby/lamby.py
+++ b/lamby/lamby.py
@@ -5,6 +5,7 @@ import json
 import time
 import hashlib
 import gzip
+import glob
 
 
 @click.group()
@@ -52,6 +53,9 @@ def commit(files, message):
     if not os.path.isdir(lamby_dir):
         click.echo('Lamby project has not been initialized in ' + os.getcwd())
         return
+
+    if len(files) == 0:
+        files = search_file_type('.', 'onnx')
 
     log = deserialize_log()
 
@@ -144,6 +148,10 @@ def diff_gzip(fname, compressed_object_path):
             compressed_sha.update(chunk)
         compressed_object.close()
         return current_hash == compressed_sha.hexdigest()
+
+
+def search_file_type(directory, ftype):
+    return glob.iglob(directory + '/**/*.' + ftype, recursive=True)
 
 
 if __name__ == '__main__':

--- a/lamby/lamby.py
+++ b/lamby/lamby.py
@@ -55,8 +55,10 @@ def commit(files, message):
         click.echo('Lamby project has not been initialized in ' + os.getcwd())
         sys.exit(1)
 
+    files = search_file_type('.', 'onnx') if len(files) == 0 else files
     if len(files) == 0:
-        files = search_file_type('.', 'onnx')
+        click.echo('There are no onnx files in the project directory.')
+        sys.exit(1)
 
     log = deserialize_log()
 

--- a/lamby/lamby.py
+++ b/lamby/lamby.py
@@ -119,6 +119,7 @@ def file_sha256(fname):
     with open(fname, "rb") as f:
         for chunk in iter(lambda: f.read(4096), b""):
             hash_sha256.update(chunk)
+        f.close()
     return hash_sha256.hexdigest()
 
 

--- a/lamby/lamby.py
+++ b/lamby/lamby.py
@@ -44,6 +44,10 @@ def uninit():
 @click.argument('files', nargs=-1)
 @click.option('-m', '--message')
 def commit(files, message):
+    lamby_dir = os.getcwd() + '/.lamby'
+    if not os.path.isdir(lamby_dir):
+        click.echo('Lamby project has not been initialized in ' + os.getcwd())
+        return
     click.echo('Commiting following files:')
     for file in files:
         click.echo('\t' + file)

--- a/lamby/lamby.py
+++ b/lamby/lamby.py
@@ -61,6 +61,9 @@ def commit(files, message):
     log = deserialize_log()
 
     for file in files:
+
+        basename = os.path.basename(file)
+
         if not os.path.isfile(file):
             click.echo(file + ' is not a file')
             continue
@@ -70,9 +73,9 @@ def commit(files, message):
             continue
 
         if file not in log:
-            log[file] = []
+            log[basename] = []
         elif diff_gzip(file, './.lamby/commit_objects/' +
-                       log[file][-1]['hash']):
+                       log[basename][-1]['hash']):
             click.echo(file + ' has no changes to commit')
             continue
 
@@ -80,20 +83,20 @@ def commit(files, message):
         commit_record["timestamp"] = int(time.time())
         commit_record["message"] = str(message)
 
-        str_to_hash = os.path.basename(file)
+        str_to_hash = basename
         str_to_hash += str(commit_record["timestamp"])
         str_to_hash += commit_record["message"]
         str_to_hash += file_sha256(file)
 
-        if len(log[file]) > 0:
-            str_to_hash += log[file][-1]["hash"]
+        if len(log[basename]) > 0:
+            str_to_hash += log[basename][-1]["hash"]
 
         str_to_hash = str_to_hash.encode("utf-8")
 
         hash_gen = hashlib.sha256(str_to_hash).hexdigest()
 
         commit_record["hash"] = hash_gen
-        log[file].append(commit_record)
+        log[basename].append(commit_record)
 
         with open(file, 'rb') as commit_file:
             with gzip.open('./.lamby/commit_objects/'

--- a/lamby/lamby.py
+++ b/lamby/lamby.py
@@ -20,6 +20,7 @@ def init():
         return
 
     os.mkdir(lamby_dir)
+    os.mkdir(lamby_dir + '/commit_objects')
 
     config_file = open(lamby_dir + '/config', "w+")
     config_file.write(json.dumps({}))
@@ -78,7 +79,8 @@ def commit(files, message):
         log[file].append(commit_record)
 
         with open(file, 'rb') as commit_file:
-            with gzip.open('./.lamby/' + hash_gen, 'wb') as zipped_commit:
+            with gzip.open('./.lamby/commit_objects/'
+                           + hash_gen, 'wb') as zipped_commit:
                 zipped_commit.writelines(commit_file)
                 zipped_commit.close()
                 commit_file.close()

--- a/lamby/lamby.py
+++ b/lamby/lamby.py
@@ -55,22 +55,23 @@ def commit(files, message):
         click.echo('Lamby project has not been initialized in ' + os.getcwd())
         sys.exit(1)
 
-    if files is None or len(files) == 0:
+    if len(files) == 0:
         files = search_file_type('.', 'onnx')
+
+    for file in files:
+        if not os.path.isfile(file):
+            click.echo(file + ' is not a file')
+            sys.exit(1)
+
+        if file.split('.')[-1] != 'onnx':
+            click.echo(file + ' is not an onnx file')
+            sys.exit(1)
 
     log = deserialize_log()
 
     for file in files:
 
         basename = os.path.basename(file)
-
-        if not os.path.isfile(file):
-            click.echo(file + ' is not a file')
-            continue
-
-        if file.split('.')[-1] != 'onnx':
-            click.echo(file + ' is not an onnx file')
-            continue
 
         if file not in log:
             log[basename] = []
@@ -155,7 +156,10 @@ def diff_gzip(fname, compressed_object_path):
 
 
 def search_file_type(directory, ftype):
-    return glob.iglob(directory + '/**/*.' + ftype, recursive=True)
+    results = []
+    for file in glob.iglob(directory + '/**/*.' + ftype, recursive=True):
+        results.append(file)
+    return results
 
 
 if __name__ == '__main__':

--- a/test/commit_test.py
+++ b/test/commit_test.py
@@ -11,21 +11,21 @@ def test_commit_basic(runner):
 
         runner.invoke(init)
 
-        filename = "file1.txt"
-        message = "Foo Bar!"
+        filename = 'file1.onnx'
+        message = 'Foo Bar!'
 
         create_file(filename, 100)
 
-        result = runner.invoke(commit, [filename, "-m", message])
+        result = runner.invoke(commit, [filename, '-m', message])
 
         assert result.exit_code == 0
 
         log_file = deserialize_log()
         compressed_filename = './.lamby/commit_objects/' + \
-            log_file[filename][0]["hash"]
-        uncompressed_filename = log_file[filename][0]["hash"]
+            log_file[filename][0]['hash']
+        uncompressed_filename = log_file[filename][0]['hash']
 
-        assert log_file[filename][0]["message"] == message
+        assert log_file[filename][0]['message'] == message
         assert os.path.isfile(compressed_filename)
 
         with gzip.open(compressed_filename, 'rb') as compressed_file:

--- a/test/commit_test.py
+++ b/test/commit_test.py
@@ -1,0 +1,41 @@
+import os
+import gzip
+import shutil
+import filecmp
+from click.testing import CliRunner
+from test.utils import create_file
+from lamby.lamby import init, commit, deserialize_log
+
+
+def test_commit_basic():
+
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+
+        runner.invoke(init)
+
+        filename = "file1.txt"
+        message = "Foo Bar!"
+
+        create_file(filename, 100)
+
+        result = runner.invoke(commit, [filename, "-m", message])
+
+        assert result.exit_code == 0
+
+        log_file = deserialize_log()
+        compressed_filename = './.lamby/commit_objects/' + \
+            log_file[filename][0]["hash"]
+        uncompressed_filename = log_file[filename][0]["hash"]
+
+        assert log_file[filename][0]["message"] == message
+        assert os.path.isfile(compressed_filename)
+
+        with gzip.open(compressed_filename, 'rb') as compressed_file:
+            with open(uncompressed_filename, 'wb') as uncompressed_file:
+                shutil.copyfileobj(compressed_file, uncompressed_file)
+                compressed_file.close()
+                uncompressed_file.close()
+
+        filecmp.clear_cache()
+        assert filecmp.cmp(filename, uncompressed_filename)

--- a/test/commit_test.py
+++ b/test/commit_test.py
@@ -2,14 +2,11 @@ import os
 import gzip
 import shutil
 import filecmp
-from click.testing import CliRunner
 from test.utils import create_file
 from lamby.lamby import init, commit, deserialize_log
 
 
-def test_commit_basic():
-
-    runner = CliRunner()
+def test_commit_basic(runner):
     with runner.isolated_filesystem():
 
         runner.invoke(init)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,7 @@
+import pytest
+from click.testing import CliRunner
+
+
+@pytest.fixture(scope="package")
+def runner():
+    return CliRunner()

--- a/test/init_test.py
+++ b/test/init_test.py
@@ -1,10 +1,8 @@
-from click.testing import CliRunner
 import os
 from lamby.lamby import init
 
 
-def test_init():
-    runner = CliRunner()
+def test_init(runner):
     with runner.isolated_filesystem():
         result = runner.invoke(init, [])
 

--- a/test/init_test.py
+++ b/test/init_test.py
@@ -1,5 +1,5 @@
 import os
-from lamby.lamby import init, uninit
+from lamby.lamby import init
 
 
 def test_init(runner):
@@ -19,12 +19,3 @@ def test_init(runner):
         with open('./.lamby/log', 'r') as log_file:
             data = log_file.read()
             assert data == '{}'
-
-
-def test_uninit(runner):
-    with runner.isolated_filesystem():
-        result = runner.invoke(init, [])
-        result = runner.invoke(uninit, [])
-
-        assert result.exit_code == 0
-        assert not os.path.isdir('./.lamby')

--- a/test/init_test.py
+++ b/test/init_test.py
@@ -1,5 +1,5 @@
 import os
-from lamby.lamby import init
+from lamby.lamby import init, uninit
 
 
 def test_init(runner):
@@ -19,3 +19,12 @@ def test_init(runner):
         with open('./.lamby/log', 'r') as log_file:
             data = log_file.read()
             assert data == '{}'
+
+
+def test_uninit(runner):
+    with runner.isolated_filesystem():
+        result = runner.invoke(init, [])
+        result = runner.invoke(uninit, [])
+
+        assert result.exit_code == 0
+        assert not os.path.isdir('./.lamby')

--- a/test/init_test.py
+++ b/test/init_test.py
@@ -10,6 +10,7 @@ def test_init():
 
         assert result.exit_code == 0
         assert os.path.isdir('./.lamby')
+        assert os.path.isdir('./.lamby/commit_objects')
         assert os.path.isfile('./.lamby/config')
         assert os.path.isfile('./.lamby/log')
 

--- a/test/uninit_test.py
+++ b/test/uninit_test.py
@@ -1,0 +1,11 @@
+import os
+from lamby.lamby import init, uninit
+
+
+def test_uninit(runner):
+    with runner.isolated_filesystem():
+        result = runner.invoke(init, [])
+        result = runner.invoke(uninit, [])
+
+        assert result.exit_code == 0
+        assert not os.path.isdir('./.lamby')

--- a/test/utils.py
+++ b/test/utils.py
@@ -1,6 +1,9 @@
 import os
 import string
 import random
+import shutil
+import gzip
+import filecmp
 
 
 def create_file(filename, N):
@@ -18,3 +21,16 @@ def mutate_file(filename, N):
         string.ascii_uppercase + string.digits, k=N))
     file.write(random_string + '\n')
     file.close()
+
+
+def unzip_to(zipped_filename, dest_filename):
+    with gzip.open(zipped_filename, 'rb') as compressed_file:
+        with open(dest_filename, 'wb') as uncompressed_file:
+            shutil.copyfileobj(compressed_file, uncompressed_file)
+            compressed_file.close()
+            uncompressed_file.close()
+
+
+def cmp_files(file1, file2):
+    filecmp.clear_cache()
+    return filecmp.cmp(file1, file2)

--- a/test/utils.py
+++ b/test/utils.py
@@ -1,0 +1,20 @@
+import os
+import string
+import random
+
+
+def create_file(filename, N):
+    file = open(filename, 'w+')
+    random_string = ''.join(random.choices(
+        string.ascii_uppercase + string.digits, k=N))
+    file.write(random_string + '\n')
+    file.close()
+
+
+def mutate_file(filename, N):
+    assert os.path.isfile(filename)
+    file = open(filename, 'a')
+    random_string = ''.join(random.choices(
+        string.ascii_uppercase + string.digits, k=N))
+    file.write(random_string + '\n')
+    file.close()


### PR DESCRIPTION
Built out lamby commit. version histories are made based on path **basename**. File is hashed along with timestamp and message, this creates the commit hash. Previous hash is included if there is a previous hash. This hash is going to be used as the filename in `./.lamby/commit_objects/`. Will only commit if the file is different from the previous version, if there exists one. Comparison is done by generating a hash of the previous and the current file.

This will also commit all onnx files in the directory, recursively, if there are no files specified. ONLY onnx files are accepted.

Basic tests added for init, uninit, commit.