### PR TITLE
Removed gzip and test dependencies on compression.

### DIFF
--- a/lamby/src/checkout.py
+++ b/lamby/src/checkout.py
@@ -2,8 +2,8 @@ import sys
 
 import click
 
-from lamby.src.utils import (deserialize_log, deserialize_meta, diff_gzip,
-                             search_pattern, serialize_meta, unzip_to)
+from lamby.src.utils import (deserialize_log, deserialize_meta, diff_files,
+                             search_pattern, serialize_meta, copy_file)
 
 
 @click.command('checkout', short_help='checkout a commit hash')
@@ -42,12 +42,12 @@ def checkout(hash):
         # TODO: add check for duplicate filenames
         file_path = file_search_results[0]
 
-        if not diff_gzip(file_path, './.lamby/commit_objects/' +
-                         meta['file_head'][result_name]['hash']):
+        if not diff_files(file_path, './.lamby/commit_objects/' +
+                          meta['file_head'][result_name]['hash']):
             click.echo('Cannot checkout with uncommitted changes')
             sys.exit(1)
 
-        unzip_to('./.lamby/commit_objects/' + result_hash, file_path)
+        copy_file('./.lamby/commit_objects/' + result_hash, file_path)
 
         meta['file_head'][result_name] = {
             'hash': result_hash,

--- a/lamby/src/clone.py
+++ b/lamby/src/clone.py
@@ -5,7 +5,7 @@ import click
 
 from lamby.src.init import init
 from lamby.src.utils import (get_request, serialize_config, serialize_log,
-                             serialize_meta, unzip_to)
+                             serialize_meta, copy_file)
 
 
 @click.command('clone', short_help='clone a repository into current directory')
@@ -63,7 +63,7 @@ def clone(project_id):
             'index': len(log[res["commits"][chunk]["filename"]]) - 1
         }
         filename = res["commits"][chunk]["filename"]
-        unzip_to(f"{commit_objects_dir}/{commit_id}", filename)
+        copy_file(f"{commit_objects_dir}/{commit_id}", filename)
 
     latest_chunks = list(res["latest_commits"].keys())
     for chunk in latest_chunks:

--- a/lamby/src/commit.py
+++ b/lamby/src/commit.py
@@ -1,4 +1,3 @@
-import gzip
 import hashlib
 import os
 import sys
@@ -6,9 +5,9 @@ import time
 
 import click
 
-from lamby.src.utils import (deserialize_log, deserialize_meta, diff_gzip,
-                             file_sha256, search_file_type, serialize_log,
-                             serialize_meta)
+from lamby.src.utils import (deserialize_log, deserialize_meta, diff_files,
+                             copy_file, file_sha256, search_file_type,
+                             serialize_log, serialize_meta)
 
 
 @click.command('commit', short_help='commit all changes in ')
@@ -46,8 +45,8 @@ def commit(files, message):
             click.echo(file + ' is not an onnx file')
             file_errors = True
 
-        if basename in log and diff_gzip(file, './.lamby/commit_objects/' +
-                                         log[basename][-1]['hash']):
+        if basename in log and diff_files(file, './.lamby/commit_objects/' +
+                                          log[basename][-1]['hash']):
             click.echo(file + ' has no changes to commit')
             file_errors = True
 
@@ -87,12 +86,7 @@ def commit(files, message):
         }
         meta['latest_commit'][basename] = hash_gen
 
-        with open(file, 'rb') as commit_file:
-            with gzip.open('./.lamby/commit_objects/'
-                           + hash_gen, 'wb') as zipped_commit:
-                zipped_commit.writelines(commit_file)
-                zipped_commit.close()
-                commit_file.close()
+        copy_file(file, './.lamby/commit_objects/' + hash_gen)
 
     serialize_log(log)
     serialize_meta(meta)

--- a/lamby/src/pull.py
+++ b/lamby/src/pull.py
@@ -5,7 +5,7 @@ import click
 
 from lamby.src.utils import (deserialize_config, deserialize_log,
                              deserialize_meta, get_request, serialize_log,
-                             serialize_meta, unzip_to)
+                             serialize_meta, copy_file)
 
 
 @click.command('pull', short_help='pull changes from lamby web')
@@ -62,7 +62,7 @@ def pull():
             meta['file_head'][c_filename] = {'index': 0}
 
         meta['file_head'][c_filename]['hash'] = c_hash
-        unzip_to('./.lamby/commit_objects/'+c_hash, './'+c_filename)
+        copy_file('./.lamby/commit_objects/'+c_hash, './'+c_filename)
 
     for c_hash in res_json['latest_commits']:
         c_filename = res_json['latest_commits'][c_hash]['filename']

--- a/lamby/src/status.py
+++ b/lamby/src/status.py
@@ -2,7 +2,7 @@ import sys
 
 import click
 
-from lamby.src.utils import deserialize_meta, diff_gzip, search_pattern
+from lamby.src.utils import deserialize_meta, diff_files, search_pattern
 
 
 @click.command('status', short_help='check the status of the .onnx files in ' +
@@ -31,6 +31,6 @@ def status():
                 file+': On a previous hash starting with '+file_head[:4])
             click.echo(file+': Latest hash starts with ' +
                        latest_commit[:4])
-        if not diff_gzip(file_name, './.lamby/commit_objects/' +
-                         meta["file_head"][file]["hash"]):
+        if not diff_files(file_name, './.lamby/commit_objects/' +
+                          meta["file_head"][file]["hash"]):
             click.echo(file_name+': This file has uncommitted changes')

--- a/lamby/src/utils.py
+++ b/lamby/src/utils.py
@@ -1,5 +1,4 @@
 import glob
-import gzip
 import hashlib
 import json
 import os
@@ -94,14 +93,8 @@ def file_sha256(fname):
 
 
 # Currently done by hash comparison, a little hacky.
-def diff_gzip(fname, compressed_object_path):
-    current_hash = file_sha256(fname)
-    with gzip.open(compressed_object_path, 'rb') as compressed_object:
-        compressed_sha = hashlib.sha256()
-        for chunk in iter(lambda: compressed_object.read(4096), b""):
-            compressed_sha.update(chunk)
-        compressed_object.close()
-        return current_hash == compressed_sha.hexdigest()
+def diff_files(fname1, fname2):
+    return file_sha256(fname1) == file_sha256(fname2)
 
 
 def search_file_type(directory, ftype):
@@ -115,8 +108,9 @@ def search_pattern(pattern):
     return results
 
 
-def unzip_to(zipped_filename, dest_filename):
-    with gzip.open(zipped_filename, 'rb') as compressed_file:
+# Refactor copy_file
+def copy_file(zipped_filename, dest_filename):
+    with open(zipped_filename, 'rb') as compressed_file:
         with open(dest_filename, 'wb') as uncompressed_file:
             shutil.copyfileobj(compressed_file, uncompressed_file)
             compressed_file.close()

--- a/lamby/test/commit_test.py
+++ b/lamby/test/commit_test.py
@@ -2,7 +2,7 @@ import os
 
 from lamby.src.commit import commit
 from lamby.src.init import init  # NOQA
-from lamby.src.utils import deserialize_log, unzip_to
+from lamby.src.utils import deserialize_log, copy_file
 from lamby.test.utils import cmp_files, create_file
 
 
@@ -45,7 +45,7 @@ def test_commit_basic(runner):
         assert log_file[filename][0]['message'] == message
         assert os.path.isfile(compressed_filename)
 
-        unzip_to(compressed_filename, uncompressed_filename)
+        copy_file(compressed_filename, uncompressed_filename)
 
         assert cmp_files(filename, uncompressed_filename)
 
@@ -88,7 +88,7 @@ def test_commit_no_spec_file(runner):
 
         assert os.path.isfile(compressed_filename)
 
-        unzip_to(compressed_filename, uncompressed_filename)
+        copy_file(compressed_filename, uncompressed_filename)
 
         assert cmp_files('file1.onnx', uncompressed_filename)
 
@@ -98,6 +98,6 @@ def test_commit_no_spec_file(runner):
 
         assert os.path.isfile(compressed_filename)
 
-        unzip_to(compressed_filename, uncompressed_filename)
+        copy_file(compressed_filename, uncompressed_filename)
 
         assert cmp_files('dir1/file2.onnx', uncompressed_filename)

--- a/lamby/test/status_test.py
+++ b/lamby/test/status_test.py
@@ -1,4 +1,3 @@
-import gzip
 import os
 
 from lamby.src.checkout import checkout
@@ -6,7 +5,7 @@ from lamby.src.commit import commit
 from lamby.src.init import init
 from lamby.src.status import status
 from lamby.src.uninit import uninit  # NOQA
-from lamby.src.utils import deserialize_log
+from lamby.src.utils import deserialize_log, copy_file
 from lamby.test.utils import create_file
 
 
@@ -46,24 +45,9 @@ def test_status_basic(runner):
         create_file('f2.onnx', 500)
         create_file('f3.onnx', 500)
 
-        with open('f1.onnx', 'rb') as commit_file:
-            with gzip.open('./.lamby/commit_objects/'
-                           + "hash1", 'wb') as zipped_commit:
-                zipped_commit.writelines(commit_file)
-                zipped_commit.close()
-                commit_file.close()
-        with open('f2.onnx', 'rb') as commit_file:
-            with gzip.open('./.lamby/commit_objects/'
-                           + "hash2", 'wb') as zipped_commit:
-                zipped_commit.writelines(commit_file)
-                zipped_commit.close()
-                commit_file.close()
-        with open('f3.onnx', 'rb') as commit_file:
-            with gzip.open('./.lamby/commit_objects/'
-                           + "hash3", 'wb') as zipped_commit:
-                zipped_commit.writelines(commit_file)
-                zipped_commit.close()
-                commit_file.close()
+        copy_file('f1.onnx', './.lamby/commit_objects/' + "hash1")
+        copy_file('f2.onnx', './.lamby/commit_objects/' + "hash2")
+        copy_file('f3.onnx', './.lamby/commit_objects/' + "hash3")
 
         result = runner.invoke(status)
         assert result.exit_code == 0


### PR DESCRIPTION
Transition to removing gzip compression for model protobufs. Use copy_files function for copying files in and out of commit objects and diff_files to quickly compare files.